### PR TITLE
Add database as output type for ML inference

### DIFF
--- a/src/flood_forecaster/data_ingestion/load.py
+++ b/src/flood_forecaster/data_ingestion/load.py
@@ -52,11 +52,6 @@ def load_river_level_db(config: Config, locations: Iterable[str], date_begin: da
     return pd.read_sql(stmt, database.engine)
 
 
-def insert_predicted_river_level_db(df):
-    # TODO: Implement this function and move
-    pass
-
-
 def __load_csv(path, start_date=None, end_date=None, datefmt="%Y-%m-%d"):
     df = pd.read_csv(path)
     # convert date column to datetime and drop time information
@@ -213,6 +208,9 @@ def load_inference_weather(config: Config, locations=None, date=datetime.now()) 
         - precipitation_hours: float
     """
 
+    # ignore time information in date
+    date = date.date()
+
     model_config = config.load_model_config()
 
     # load historical weather data for the last max(WEATHER_LAG) days
@@ -223,7 +221,7 @@ def load_inference_weather(config: Config, locations=None, date=datetime.now()) 
     # LAG=0 is the current day, so it is part of the forecast
     max_date = date - timedelta(days=min(json.loads(model_config["weather_lag_days"])))
 
-    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today = datetime.now().date()
 
     # if max_date is in the future, we will need to load forecast data
     # exclude today from historical data
@@ -264,6 +262,9 @@ def load_inference_river_levels(config: Config, locations=None, date=datetime.no
         - date: datetime
         - level__m: float
     """
+    # ignore time information in date
+    date = date.date()
+
     model_config = config.load_model_config()
     min_date = date - timedelta(days=max(json.loads(model_config["river_station_lag_days"])))
     max_date = date - timedelta(days=1)

--- a/src/flood_forecaster/ml_model/DESIGN.md
+++ b/src/flood_forecaster/ml_model/DESIGN.md
@@ -31,3 +31,4 @@ The `ml_model` package consists of the following files:
 - river_stations_metadata used in the eval function to load the threshold values.
   It is not used in the training or inference. 
   Will be removed in the future as it is handled by the data module.
+- @Adina: Might be useful to add a _Const(object) class to keep all const definitions in one place, like STDOUT, DB, ENVFILE, but also other static params used like PREDICTION_LEVEL, .. see [PR#59](https://github.com/saadaal-dev/saadaal-flood-forecaster/pull/59#discussion_r2143111696)

--- a/src/flood_forecaster/ml_model/inference.py
+++ b/src/flood_forecaster/ml_model/inference.py
@@ -1,5 +1,12 @@
+from datetime import datetime
+
 from src.flood_forecaster.ml_model.preprocess import preprocess_diff
 from src.flood_forecaster.ml_model.registry import ModelManager
+from src.flood_forecaster.utils.database_helper import DatabaseConnection
+from sqlalchemy import insert
+
+
+DB_PREDICTED_RIVER_LEVEL = "predicted_river_level"
 
 
 def infer_from_raw_data(model_manager: ModelManager, model_path, model_name, station_metadata, stations_df, weather_df, station_lag_days, weather_lag_days, forecast_days):
@@ -28,3 +35,49 @@ def infer_from_raw_data(model_manager: ModelManager, model_path, model_name, sta
     model = model_manager.load(model_path, model_name)
 
     return model_manager.infer(model, df)
+
+
+def create_inference_insert_statement(
+        location: str,
+        model_name: str,
+        forecast_days: int,
+        date: datetime,
+        level_m: float,
+) -> insert:
+    """
+    Create an SQL insert statement to store inference results.
+    
+    Args:
+        location: The location of the station.
+        model_name: The name of the model used for inference.
+        forecast_days: how many days ahead the prediction is made for (1=today).
+        date: The timestamp of the inference.
+        level_m: The predicted river level in meters.
+    
+    Returns:
+        An SQLAlchemy insert statement.
+    """
+    return insert(DB_PREDICTED_RIVER_LEVEL).values(
+        location=location,
+        model_name=model_name,
+        forecast_days=forecast_days,
+        date=date,
+        level_m=level_m
+    )
+
+
+def store_inference_result(db_connection: DatabaseConnection, location, model_name, forecast_days, date, level_m):
+    """
+    Store the inference result in the database.
+    
+    Args:
+        location: The location of the station.
+        model_name: The name of the model used for inference.
+        forecast_days: how many days ahead the prediction is made for (1=today).
+        date: The timestamp of the inference.
+        level_m: The predicted river level in meters.
+    """
+    with db_connection.engine.connect() as conn:
+        insert_stmt = create_inference_insert_statement(location, model_name, forecast_days, date, level_m)
+        conn.execute(insert_stmt)
+        conn.commit()

--- a/src/flood_forecaster/utils/configuration.py
+++ b/src/flood_forecaster/utils/configuration.py
@@ -23,6 +23,20 @@ class DataSourceType(Enum):
         raise ValueError(f"Unsupported data source type: {source_type}")
 
 
+# Output type
+class DataOutputType(Enum):
+    STDOUT = "stdout"
+    DATABASE = "database"
+
+    @classmethod
+    def from_string(cls, source_type: str):
+        source_type = source_type.strip().lower()
+        for item in cls:
+            if item.value == source_type:
+                return item
+        raise ValueError(f"Unsupported data source type: {source_type}")
+
+
 class Config:
     def __init__(self, config_file_path: str) -> None:
         self._config: ConfigParser = self._load_config(config_file_path)


### PR DESCRIPTION
# What is the feature/issue

- adding the possibility to store inference results into a SQL table

## Description of changes

- CLI now supports the `--output_type` option supporting `stdout` (default) and `database` values.
- new `DataOutputType` enum
- code to support data storage if `DataOutputType.DATABASE` is selected
- cleanup of empty method in `load.py` (this part is specific to the ml application; as a rule of thumb we are keeping things separate if no common usage)

## How did we test it

- not tested yet (DB connection not yet tested)
- E2E test expected to cover this