### PR TITLE
added weigthed_rmse to eval step in ml pipeline

### DIFF
--- a/src/flood_forecaster_cli/commands/ml_model.py
+++ b/src/flood_forecaster_cli/commands/ml_model.py
@@ -64,7 +64,7 @@ def preprocess(station, config_path, forecast_days):
 @click.argument('config_path', type=click.Path(exists=True, dir_okay=False), default=configuration.DEFAULT_CONFIG_FILE_PATH)
 @click.option('-f', '--forecast_days', type=click.IntRange(1, None), default=None)
 def analyze(config_path, forecast_days):
-    config = configuration.read_config(config_path)
+    config = Config(config_path)
     api.analyze(config, forecast_days)
 
 


### PR DESCRIPTION
# What is the feature/issue

- Added calculation of weighted RMSE for ML pipeline evaluation 

## Description of changes

- The weights are calculated using sigmoid function. Weights increase based on a river level. Higher the river level, higher are weights. Yet, once actual river reached high threshold, weights are plateaued. 
- Bugfix for configuration in ML CLI

## Any relevant logs or outputs

- Weighted RMSE is displayed along with RMSE and Baseline RMSE calculations. 

  